### PR TITLE
Run tests on PHP 8, PHP 7.4 and PHPUnit 9 and update PHPUnit configuration schema for PHPUnit 9.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/.gitattributes export-ignore
+/.github/workflows/ export-ignore
+/.gitignore export-ignore
+/phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
+/tests/ export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.0
           - 7.4
           - 7.3
           - 7.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
           coverage: xdebug
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
+        if: ${{ matrix.php >= 7.3 }}
+      - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
+        if: ${{ matrix.php < 7.3 }}
 
   PHPUnit-hhvm:
     name: PHPUnit (HHVM)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,14 @@ jobs:
     strategy:
       matrix:
         php:
+          - 7.4
+          - 7.3
+          - 7.2
+          - 7.1
+          - 7.0
           - 5.6
+          - 5.5
+          - 5.4
           - 5.3
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The recommended way to install this library is [through Composer](https://getcom
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.3 through current PHP 7+ and
+extensions and supports running on legacy PHP 5.3 through current PHP 8+ and
 HHVM.
 It's *highly recommended to use PHP 7+* for this project.
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ The recommended way to install this library is [through Composer](https://getcom
 }
 ```
 
+See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
+
+This project aims to run on any platform and thus does not require any PHP
+extensions and supports running on legacy PHP 5.3 through current PHP 7+ and
+HHVM.
+It's *highly recommended to use PHP 7+* for this project.
+
 ## Tests
 
 To run the test suite, you first need to clone this repo and then install all

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
     	"php": ">=5.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="tests/bootstrap.php"
+<phpunit bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php"
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
->
+         cacheResult="false">
     <testsuites>
-        <testsuite name="JSON stream Test Suite">
+        <testsuite name="JSON Stream Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="JSON Stream Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/StreamingJsonParserTest.php
+++ b/tests/StreamingJsonParserTest.php
@@ -2,11 +2,14 @@
 
 use Clue\JsonStream\StreamingJsonParser;
 
-class StreamingJsonParserTest extends TestCase
+class StreamingJsonParserTest extends PHPUnit\Framework\TestCase
 {
     private $parser;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpParser()
     {
         $this->parser = new StreamingJsonParser();
     }
@@ -57,11 +60,26 @@ class StreamingJsonParserTest extends TestCase
         $this->assertTrue($this->parser->isEmpty());
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
     public function testInvalid()
     {
+        $this->setExpectedException('UnexpectedValueException');
         $this->parser->push('invalid');
+    }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5.2+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 5.1
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,0 @@
-<?php
-
-require __DIR__ . '/../vendor/autoload.php';
-
-class TestCase extends PHPUnit_Framework_TestCase {
-}


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
For further details concerning this pull request look into https://github.com/graphp/graphviz/pull/46.
This pull request builds on top of #10.

It's also possible to run this code with PHP 8 🎉
 ```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.0 php vendor/bin/phpunit
PHPUnit 9.5.0 by Sebastian Bergmann and contributors.

........                                                            8 / 8 (100%)

Time: 00:00.007, Memory: 6.00 MB

OK (8 tests, 18 assertions)
```